### PR TITLE
Scope `logback-core` `test-jar` dependencies to tests only

### DIFF
--- a/logback-access-db/pom.xml
+++ b/logback-access-db/pom.xml
@@ -23,6 +23,7 @@
       <artifactId>logback-core</artifactId>
       <version>${logback.version}</version>
       <type>test-jar</type>
+      <scope>test</scope>
     </dependency>
       
     <dependency>

--- a/logback-classic-db/pom.xml
+++ b/logback-classic-db/pom.xml
@@ -23,6 +23,7 @@
       <artifactId>logback-core</artifactId>
       <version>${logback.version}</version>
       <type>test-jar</type>
+      <scope>test</scope>
     </dependency>
       
     <dependency>


### PR DESCRIPTION
This PR narrows dependency scoping for `test-jar` artifacts so they are only available on the test classpath. It updates module POMs to avoid leaking test fixtures into non-test dependency resolution.

- **Dependency scope corrections**
  - Added `<scope>test</scope>` to `ch.qos.logback:logback-core` dependencies declared with `<type>test-jar</type>` in:
    - `logback-access-db/pom.xml`
    - `logback-classic-db/pom.xml`

- **Classpath impact**
  - Keeps `test-jar` artifacts limited to tests.
  - Leaves normal `logback-core` runtime/compile dependency behavior unchanged.

```xml
<dependency>
  <groupId>ch.qos.logback</groupId>
  <artifactId>logback-core</artifactId>
  <version>${logback.version}</version>
  <type>test-jar</type>
  <scope>test</scope>
</dependency>
```